### PR TITLE
Bazzar: Downgraded pg to 0.20.0 from 0.21.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gem 'rails', '5.0.0.1'
 
 # Use postgres as the database for Active Record
-gem 'pg'
+gem 'pg', '~> 0.20.0'
 # Use SCSS for stylesheets
 gem 'sass-rails'
 # Use Uglifier as compressor for JavaScript assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,8 +85,8 @@ GEM
     nio4r (1.2.1)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
-    oj (2.18.1)
-    pg (0.21.0)
+    oj (3.3.9)
+    pg (0.20.0)
     rabl (0.13.1)
       activesupport (>= 2.3.14)
     rack (2.0.3)
@@ -117,14 +117,14 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (12.2.1)
+    rake (12.3.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rdoc (4.3.0)
-    redis (3.3.2)
-    redis-namespace (1.5.2)
-      redis (~> 3.0, >= 3.0.4)
+    redis (4.0.1)
+    redis-namespace (1.6.0)
+      redis (>= 3.0.4)
     sass (3.5.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -140,8 +140,8 @@ GEM
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     settingslogic (2.0.9)
-    slim (3.0.7)
-      temple (~> 0.7.6)
+    slim (3.0.9)
+      temple (>= 0.7.6, < 0.9)
       tilt (>= 1.3.3, < 2.1)
     spring (2.0.2)
       activesupport (>= 4.2)
@@ -155,7 +155,7 @@ GEM
     swagger-docs (0.2.9)
       activesupport (>= 3)
       rails (>= 3)
-    temple (0.7.7)
+    temple (0.8.0)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -186,7 +186,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   oj
-  pg
+  pg (~> 0.20.0)
   rabl
   rails (= 5.0.0.1)
   rails-patch-json-encode


### PR DESCRIPTION
  * Downgraded the pg gem to avoid the message
    The PGconn, PGresult, and PGError constants are deprecated